### PR TITLE
Add support for SPF record type

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,6 +25,7 @@ Table of Contents
     * [TYPE_TXT](#type_txt)
     * [TYPE_AAAA](#type_aaaa)
     * [TYPE_SRV](#type_srv)
+    * [TYPE_SPF](#type_spf)
     * [CLASS_IN](#class_in)
 * [Automatic Error Logging](#automatic-error-logging)
 * [Limitations](#limitations)
@@ -311,6 +312,16 @@ See RFC 2782 for details.
 
 [Back to TOC](#table-of-contents)
 
+TYPE_SPF
+---------
+`syntax: typ = r.TYPE_SPF`
+
+The `SPF` resource record type, equal to the decimal number `99`.
+
+See RFC 4408 for details.
+
+[Back to TOC](#table-of-contents)
+
 CLASS_IN
 --------
 `syntax: class = r.CLASS_IN`
@@ -352,7 +363,7 @@ TODO
 ====
 
 * Concurrent (or parallel) query mode
-* Better support for other resource record types like `SPF`.
+* Better support for other resource record types like `TLSA`.
 
 [Back to TOC](#table-of-contents)
 

--- a/lib/resty/dns/resolver.lua
+++ b/lib/resty/dns/resolver.lua
@@ -37,6 +37,7 @@ local TYPE_MX     = 15
 local TYPE_TXT    = 16
 local TYPE_AAAA   = 28
 local TYPE_SRV    = 33
+local TYPE_SPF    = 99
 
 local CLASS_IN    = 1
 
@@ -51,6 +52,7 @@ local _M = {
     TYPE_TXT    = TYPE_TXT,
     TYPE_AAAA   = TYPE_AAAA,
     TYPE_SRV    = TYPE_SRV,
+    TYPE_SPF    = TYPE_SPF,
     CLASS_IN    = CLASS_IN,
 }
 
@@ -560,7 +562,9 @@ local function parse_response(buf, id)
 
             ans.nsdname = name
 
-        elseif typ == TYPE_TXT then
+        elseif typ == TYPE_TXT or typ == TYPE_SPF then
+
+            local key = (typ == TYPE_TXT) and "txt" or "spf"
 
             local slen = byte(buf, pos)
             if slen + 1 > len then
@@ -596,7 +600,7 @@ local function parse_response(buf, id)
                 until pos >= last
             end
 
-            ans.txt = val
+            ans[key] = val
 
         elseif typ == TYPE_PTR then
 


### PR DESCRIPTION
The implementation of SPF is the same as TXT

> This document defines a new DNS RR of type SPF, code 99.  The format of this type is identical to the TXT RR [RFC1035].  For either type, the character content of the record is encoded as [US-ASCII].
> ... from http://www.ietf.org/rfc/rfc4408.txt

SPF values are exposed via `ans.spf`.
