### PR TITLE
parses addresses in all the sections

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,6 +30,9 @@ Table of Contents
     * [TYPE_SRV](#type_srv)
     * [TYPE_SPF](#type_spf)
     * [CLASS_IN](#class_in)
+    * [SECTION_AN](#section_an)
+    * [SECTION_NS](#section_ns)
+    * [SECTION_AR](#section_ar)
 * [Automatic Error Logging](#automatic-error-logging)
 * [Limitations](#limitations)
 * [TODO](#todo)
@@ -152,6 +155,9 @@ which usually takes some of the following fields:
 * `address`
 
 	The IPv4 or IPv6 address in their textual representations when the resource record type is either `1` (`TYPE_A`) or `28` (`TYPE_AAAA`), respectively. Secussesive 16-bit zero groups in IPv6 addresses will not be compressed by default, if you want that, you need to call the `compress_ipv6_addr` static method instead.
+* `section`
+
+	The section in the dns response. Tells you which section is the answer comes from. Possible values are `1` (`SECTION_AN`) or `2` (`SECTION_NS`) or `3` (`SECTION_AR`).
 * `cname`
 
 	The (decoded) record data value for `CNAME` resource records. Only present for `CNAME` records.
@@ -185,6 +191,15 @@ This method also takes an optional `options` argument table, which takes the fol
 * `qtype`
 
 	The type of the question. Possible values are `1` (`TYPE_A`), `5` (`TYPE_CNAME`), `28` (`TYPE_AAAA`), or any other QTYPE value specified by RFC 1035 and RFC 3596. Default to `1` (`TYPE_A`).
+
+* `authority_section`
+
+	The `answers` includes authority section of the dns response or not. Possible values are `true`, `false`. Default to `false`.
+
+* `additional_section`
+
+	The `answers` includes additional section of the dns response or not. Possible values are `true`, `false`. Default to `false`.
+
 
 When data truncation happens, the resolver will automatically retry using the TCP transport mode
 to query the current nameserver. All TCP connections are short lived.
@@ -378,6 +393,24 @@ CLASS_IN
 The `Internet` resource record type, equal to the decimal number `1`.
 
 [Back to TOC](#table-of-contents)
+
+SECTION_AN
+----------
+`syntax: stype = r.SECTION_AN`
+
+The `Answer` section in the DNS response, equal to the decimal number `1`
+
+SECTION_NS
+----------
+`syntax: stype = r.SECTION_NS`
+
+The `Authority` section in the DNS response, equal to the decimal number `2`
+
+SECTION_AR
+----------
+`syntax: stype = r.SECTION_AR`
+
+The `Additional` section in the DNS response, equal to the decimal number `3`
 
 Automatic Error Logging
 =======================

--- a/t/mock.t
+++ b/t/mock.t
@@ -65,7 +65,7 @@ GET /t
 --- udp_query eval
 "\x{00}}\x{01}\x{00}\x{00}\x{01}\x{00}\x{00}\x{00}\x{00}\x{00}\x{00}\x{03}www\x{06}google\x{03}com\x{00}\x{00}\x{01}\x{00}\x{01}"
 --- response_body
-records: [{"address":"127.0.0.1","type":1,"class":1,"name":"www.google.com","ttl":123456}]
+records: [{"address":"127.0.0.1","section":1,"type":1,"class":1,"name":"www.google.com","ttl":123456}]
 --- no_error_log
 [error]
 
@@ -229,7 +229,7 @@ connect() failed
 --- request
 GET /t
 --- response_body
-records: [{"address":"127.0.0.1","type":1,"class":1,"name":"www.google.com","ttl":123456},{"address":"0:0:0:0:0:0:0:1","type":28,"class":1,"name":"l.www.google.com","ttl":0}]
+records: [{"address":"127.0.0.1","section":1,"type":1,"class":1,"name":"www.google.com","ttl":123456},{"address":"0:0:0:0:0:0:0:1","section":1,"type":28,"class":1,"name":"l.www.google.com","ttl":0}]
 --- no_error_log
 [error]
 
@@ -275,7 +275,7 @@ records: [{"address":"127.0.0.1","type":1,"class":1,"name":"www.google.com","ttl
 --- request
 GET /t
 --- response_body
-records: [{"ttl":125,"type":5,"class":1,"name":"www.google.com","cname":"blah.google.com"}]
+records: [{"section":1,"ttl":125,"type":5,"class":1,"name":"www.google.com","cname":"blah.google.com"}]
 --- no_error_log
 [error]
 
@@ -512,7 +512,7 @@ lua udp socket read timed out
 --- request
 GET /t
 --- response_body
-records: [{"address":"ff01:0:0:0:0:0:0:101","type":28,"class":1,"name":"l.www.google.com","ttl":0}]
+records: [{"address":"ff01:0:0:0:0:0:0:101","section":1,"type":28,"class":1,"name":"l.www.google.com","ttl":0}]
 --- error_log
 lua udp socket read timed out
 --- timeout: 3
@@ -667,7 +667,7 @@ records: {"errcode":1,"errstr":"format error"}
 GET /t
 --- response_body
 error code: 2: server failure
-record: {"address":"127.0.0.1","type":1,"class":1,"name":"www.google.com","ttl":123456}
+record: {"address":"127.0.0.1","section":1,"type":1,"class":1,"name":"www.google.com","ttl":123456}
 --- no_error_log
 [error]
 
@@ -1112,7 +1112,7 @@ GET /t
 --- udp_query eval
 "\x{00}}\x{01}\x{00}\x{00}\x{01}\x{00}\x{00}\x{00}\x{00}\x{00}\x{00}\x{03}www\x{06}google\x{03}com\x{00}\x{00}\x{01}\x{00}\x{01}"
 --- response_body
-records: [{"address":"127.0.0.1","type":1,"class":1,"name":"www.google.com","ttl":123456}]
+records: [{"address":"127.0.0.1","section":1,"type":1,"class":1,"name":"www.google.com","ttl":123456}]
 --- error_log
 id mismatch in the DNS reply: 126 ~= 125
 id mismatch in the DNS reply: 120 ~= 125
@@ -1173,7 +1173,7 @@ id mismatch in the DNS reply: 127 ~= 125
 --- request
 GET /t
 --- response_body
-records: [{"address":"127.0.0.1","type":1,"class":1,"name":"www.google.com","ttl":123456},{"address":"0:0:0:0:0:0:0:1","type":28,"class":1,"name":"l.www.google.com","ttl":0}]
+records: [{"address":"127.0.0.1","section":1,"type":1,"class":1,"name":"www.google.com","ttl":123456},{"address":"0:0:0:0:0:0:0:1","section":1,"type":28,"class":1,"name":"l.www.google.com","ttl":0}]
 --- no_error_log
 [error]
 --- error_log
@@ -1226,7 +1226,7 @@ query the TCP server due to reply truncation
 --- request
 GET /t
 --- response_body
-records: [{"address":"127.0.0.1","type":1,"class":1,"name":"www.google.com","ttl":123456},{"address":"0:0:0:0:0:0:0:1","type":28,"class":1,"name":"l.www.google.com","ttl":0}]
+records: [{"address":"127.0.0.1","section":1,"type":1,"class":1,"name":"www.google.com","ttl":123456},{"address":"0:0:0:0:0:0:0:1","section":1,"type":28,"class":1,"name":"l.www.google.com","ttl":0}]
 --- no_error_log
 [error]
 --- error_log
@@ -1276,7 +1276,7 @@ GET /t
 --- udp_query eval
 "\x{00}}\x{01}\x{00}\x{00}\x{01}\x{00}\x{00}\x{00}\x{00}\x{00}\x{00}\x{03}www\x{06}google\x{03}com\x{00}\x{00}\x{10}\x{00}\x{01}"
 --- response_body
-records: [{"class":1,"name":"www.google.com","ttl":123456,"txt":"hello","type":16}]
+records: [{"class":1,"name":"www.google.com","section":1,"ttl":123456,"txt":"hello","type":16}]
 --- no_error_log
 [error]
 
@@ -1323,7 +1323,7 @@ GET /t
 --- udp_query eval
 "\x{00}}\x{01}\x{00}\x{00}\x{01}\x{00}\x{00}\x{00}\x{00}\x{00}\x{00}\x{03}www\x{06}google\x{03}com\x{00}\x{00}\x{10}\x{00}\x{01}"
 --- response_body
-records: [{"class":1,"name":"www.google.com","ttl":123456,"txt":"","type":16}]
+records: [{"class":1,"name":"www.google.com","section":1,"ttl":123456,"txt":"","type":16}]
 --- no_error_log
 [error]
 
@@ -1370,7 +1370,7 @@ GET /t
 --- udp_query eval
 "\x{00}}\x{01}\x{00}\x{00}\x{01}\x{00}\x{00}\x{00}\x{00}\x{00}\x{00}\x{03}www\x{06}google\x{03}com\x{00}\x{00}\x{10}\x{00}\x{01}"
 --- response_body
-records: [{"class":1,"name":"www.google.com","ttl":123456,"txt":["hello","world"],"type":16}]
+records: [{"class":1,"name":"www.google.com","section":1,"ttl":123456,"txt":["hello","world"],"type":16}]
 --- no_error_log
 [error]
 
@@ -1417,13 +1417,210 @@ GET /t
 --- udp_query eval
 "\x{00}}\x{01}\x{00}\x{00}\x{01}\x{00}\x{00}\x{00}\x{00}\x{00}\x{00}\x{03}www\x{06}google\x{03}com\x{00}\x{00}\x{10}\x{00}\x{01}"
 --- response_body
-records: [{"class":1,"name":"www.google.com","ttl":123456,"txt":["hello","world!"],"type":16},{"class":1,"name":"www.google.com","ttl":123456,"txt":"blah","type":16}]
+records: [{"class":1,"name":"www.google.com","section":1,"ttl":123456,"txt":["hello","world!"],"type":16},{"class":1,"name":"www.google.com","section":1,"ttl":123456,"txt":"blah","type":16}]
 --- no_error_log
 [error]
 
 
 
-=== TEST 30: single answer reply, good A answer (AD is set)
+=== TEST 30: reply with authority section
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local resolver = require "resty.dns.resolver"
+
+            local r, err = resolver:new{
+                nameservers = { {"127.0.0.1", 1953} }
+            }
+            if not r then
+                ngx.say("failed to instantiate resolver: ", err)
+                return
+            end
+
+            r._id = 125
+
+            local ans, err = r:query("www.google.com", { qtype = r.SRV, authority_section = true })
+            if not ans then
+                ngx.say("failed to query: ", err)
+                return
+            end
+
+            local ljson = require "ljson"
+            ngx.say("records: ", ljson.encode(ans))
+        ';
+    }
+--- udp_listen: 1953
+--- udp_reply dns
+{
+    id => 125,
+    opcode => 0,
+    qname => "www.google.com",
+    answer => [
+        {
+            name => "www.google.com",
+            srv => "test_service.www.google.com",
+            weight => 0,
+            port => 8080,
+            priority => 1,
+            qtypt => 33,
+            ttl => 0
+        }
+    ],
+    authority => [
+        {
+            name => "test_service.www.google.com",
+            ipv4 => "127.0.0.1",
+            ttl => 0
+        }
+    ]
+}
+--- request
+GET /t
+--- response_body
+records: [{"class":1,"name":"www.google.com","port":8080,"priority":1,"section":1,"target":"test_service.www.google.com","ttl":0,"type":33,"weight":0},{"address":"127.0.0.1","class":1,"name":"test_service.www.google.com","section":2,"ttl":0,"type":1}]
+--- no_error_log
+[error]
+
+
+
+=== TEST 31: reply with additional section
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local resolver = require "resty.dns.resolver"
+
+            local r, err = resolver:new{
+                nameservers = { {"127.0.0.1", 1953} }
+            }
+            if not r then
+                ngx.say("failed to instantiate resolver: ", err)
+                return
+            end
+
+            r._id = 125
+
+            local ans, err = r:query("www.google.com", { qtype = r.SRV, additional_section = true })
+            if not ans then
+                ngx.say("failed to query: ", err)
+                return
+            end
+
+            local ljson = require "ljson"
+            ngx.say("records: ", ljson.encode(ans))
+        ';
+    }
+--- udp_listen: 1953
+--- udp_reply dns
+{
+    id => 125,
+    opcode => 0,
+    qname => "www.google.com",
+    answer => [
+        {
+            name => "www.google.com",
+            srv => "test_service.www.google.com",
+            weight => 0,
+            port => 8080,
+            priority => 1,
+            qtypt => 33,
+            ttl => 0
+        }
+    ],
+    authority => [
+        {
+            name => "test_service.www.google.com",
+            ipv4 => "127.0.0.1",
+            ttl => 0
+        }
+    ],
+    additional => [
+        {
+            name => "test_service.www.google.com",
+            ipv4 => "127.0.0.1",
+            ttl => 0
+        }
+    ]
+}
+--- request
+GET /t
+--- response_body
+records: [{"class":1,"name":"www.google.com","port":8080,"priority":1,"section":1,"target":"test_service.www.google.com","ttl":0,"type":33,"weight":0},{"address":"127.0.0.1","class":1,"name":"test_service.www.google.com","section":3,"ttl":0,"type":1}]
+--- no_error_log
+[error]
+
+
+
+=== TEST 32: reply all sections
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local resolver = require "resty.dns.resolver"
+
+            local r, err = resolver:new{
+                nameservers = { {"127.0.0.1", 1953} }
+            }
+            if not r then
+                ngx.say("failed to instantiate resolver: ", err)
+                return
+            end
+
+            r._id = 125
+
+            local ans, err = r:query("www.google.com", { qtype = r.SRV, additional_section = true, authority_section = true })
+            if not ans then
+                ngx.say("failed to query: ", err)
+                return
+            end
+
+            local ljson = require "ljson"
+            ngx.say("records: ", ljson.encode(ans))
+        ';
+    }
+--- udp_listen: 1953
+--- udp_reply dns
+{
+    id => 125,
+    opcode => 0,
+    qname => "www.google.com",
+    answer => [
+        {
+            name => "www.google.com",
+            srv => "test_service.www.google.com",
+            weight => 0,
+            port => 8080,
+            priority => 1,
+            qtypt => 33,
+            ttl => 0
+        }
+    ],
+    authority => [
+        {
+            name => "test_service.www.google.com",
+            ipv4 => "127.0.0.1",
+            ttl => 0
+        }
+    ],
+    additional => [
+        {
+            name => "test_service.www.google.com",
+            ipv4 => "127.0.0.1",
+            ttl => 0
+        }
+    ]
+}
+--- request
+GET /t
+--- response_body
+records: [{"class":1,"name":"www.google.com","port":8080,"priority":1,"section":1,"target":"test_service.www.google.com","ttl":0,"type":33,"weight":0},{"address":"127.0.0.1","class":1,"name":"test_service.www.google.com","section":2,"ttl":0,"type":1},{"address":"127.0.0.1","class":1,"name":"test_service.www.google.com","section":3,"ttl":0,"type":1}]
+--- no_error_log
+[error]
+
+
+
+=== TEST 33: single answer reply, good A answer (AD is set)
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -1464,13 +1661,13 @@ GET /t
 --- udp_query eval
 "\x{00}}\x{01}\x{00}\x{00}\x{01}\x{00}\x{00}\x{00}\x{00}\x{00}\x{00}\x{03}www\x{06}google\x{03}com\x{00}\x{00}\x{01}\x{00}\x{01}"
 --- response_body
-records: [{"address":"127.0.0.1","type":1,"class":1,"name":"www.google.com","ttl":123456}]
+records: [{"address":"127.0.0.1","section":1,"type":1,"class":1,"name":"www.google.com","ttl":123456}]
 --- no_error_log
 [error]
 
 
 
-=== TEST 31: single answer reply, good A answer (CD is set)
+=== TEST 34: single answer reply, good A answer (CD is set)
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -1511,6 +1708,6 @@ GET /t
 --- udp_query eval
 "\x{00}}\x{01}\x{00}\x{00}\x{01}\x{00}\x{00}\x{00}\x{00}\x{00}\x{00}\x{03}www\x{06}google\x{03}com\x{00}\x{00}\x{01}\x{00}\x{01}"
 --- response_body
-records: [{"address":"127.0.0.1","type":1,"class":1,"name":"www.google.com","ttl":123456}]
+records: [{"address":"127.0.0.1","section":1,"type":1,"class":1,"name":"www.google.com","ttl":123456}]
 --- no_error_log
 [error]

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -431,7 +431,7 @@ failed to query: bad name
 --- request
 GET /t
 --- response_body_like chop
-^records: \[(?:{"class":1,"name":"_xmpp-client._tcp.jabber.org","port":\d+,"priority":\d+,"target":"[\w.]+\.jabber.org","ttl":\d+,"type":33,"weight":\d+},?)+\]$
+^records: \[(?:{"class":1,"name":"_xmpp-client._tcp.jabber.org","port":\d+,"priority":\d+,"section":1,"target":"[\w.]+\.jabber.org","ttl":\d+,"type":33,"weight":\d+},?)+\]$
 --- no_error_log
 [error]
 


### PR DESCRIPTION
Hi @agentzh ,

This seems like a breaking change to this module. Basically, what this PR do is returns all the sections in the dns response. Previously, it just returns the answer section. 

This change based on our requirement that when we do a `SRV` request to our [consul](consul.io) server
to get what services are available, and what are the ip addresses + port for that specific services. It returns us:

```

$ dig @127.0.0.1 -p 8600 test_service.service.consul SRV

; <<>> DiG 9.8.3-P1 <<>> @127.0.0.1 -p 8600 test_service.service.consul SRV
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 32661
;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 2
;; WARNING: recursion requested but not available

;; QUESTION SECTION:
;test_service.service.consul.   IN      SRV

;; ANSWER SECTION:
test_service.service.consul. 0  IN      SRV     1 1 3003 zekaizhengs-mbp.corpad.net.local.node.dc1.consul.
test_service.service.consul. 0  IN      SRV     1 1 3000 zekaizhengs-mbp.corpad.net.local.node.dc1.consul.

;; ADDITIONAL SECTION:
zekaizhengs-mbp.corpad.net.local.node.dc1.consul. 0 IN A 169.254.160.242
zekaizhengs-mbp.corpad.net.local.node.dc1.consul. 0 IN A 169.254.160.242

;; Query time: 0 msec
;; SERVER: 127.0.0.1#8600(127.0.0.1)
;; WHEN: Thu Apr 14 15:45:26 2016
;; MSG SIZE  rcvd: 363
``` 

But the current `lua-resty-dns` module actually just returns us the hostname + port for the query. And from the `dig` result shows that the `additional section` already have the information I need. So in order
to make less dns request like this project: https://github.com/vlipco/srv-router/blob/master/conf/srv_router.lua#L84

I create this pr for the change. Which may breaks the current modules exists which using this module.