### PR TITLE
bugfix: issue14, wrong bit mask for RCODE

### DIFF
--- a/lib/resty/dns/resolver.lua
+++ b/lib/resty/dns/resolver.lua
@@ -335,7 +335,7 @@ local function parse_response(buf, id)
         return nil, "truncated"
     end
 
-    local code = band(flags, 0x7f)
+    local code = band(flags, 0x0f)
 
     -- print(format("code: %d", code))
 


### PR DESCRIPTION
Followup for [issue14](https://github.com/openresty/lua-resty-dns/issues/14), the AD and CD bit may be set according to [rfc2065](http://www.freesoft.org/CIE/RFC/2065/40.htm). The correct bit mast for RCODE is `0x0f`.