### PR TITLE
Stop seeding the random generator

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -61,6 +61,8 @@ Also, the [bit library](http://bitop.luajit.org/) is also required. If you're us
 
 Note that, this library is bundled and enabled by default in the [OpenResty bundle](http://openresty.org/).
 
+IMPORTANT: to be able generate unique ids, the random generator must be properly seeded using `math.randomseed` prior to using this module.
+
 Synopsis
 ========
 

--- a/lib/resty/dns/resolver.lua
+++ b/lib/resty/dns/resolver.lua
@@ -948,7 +948,4 @@ function _M.reverse_query(self, addr)
 end
 
 
-randomseed(ngx_time())
-
-
 return _M

--- a/lib/resty/dns/resolver.lua
+++ b/lib/resty/dns/resolver.lua
@@ -21,8 +21,6 @@ local re_sub = ngx.re.sub
 local tcp = ngx.socket.tcp
 local log = ngx.log
 local DEBUG = ngx.DEBUG
-local randomseed = math.randomseed
-local ngx_time = ngx.time
 local unpack = unpack
 local setmetatable = setmetatable
 local type = type
@@ -407,7 +405,6 @@ local function parse_section(answers, section, buf, start_pos, size,
 
             local addr_bytes = { byte(buf, pos, pos + 15) }
             local flds = {}
-            local comp_begin, comp_end
             for i = 1, 16, 2 do
                 local a = addr_bytes[i]
                 local b = addr_bytes[i + 1]


### PR DESCRIPTION
Seeding the random generator is a user responsibility and should never be done by modules on their own.

We've recently seen many issues due to bad-randomness, all involving bad code reseeding the random number generator (some as bad as using `os.time`). Seeding is the sole responsibility of the user. It should be seeded once, and only once, per worker process.

We reverted to patching `randomseed` globally and throw errors when is was called. This module was caught red-handed.
