### PR TITLE
bugfix: allow RRTYPE larger than 255

### DIFF
--- a/lib/resty/dns/resolver.lua
+++ b/lib/resty/dns/resolver.lua
@@ -294,7 +294,7 @@ local function _build_request(qname, id, no_recurse, opts)
     local nan = "\0\0"
     local nns = "\0\0"
     local nar = "\0\0"
-    local typ = "\0" .. char(qtype)
+    local typ = char(rshift(qtype, 8), band(qtype, 0xff))
     local class = "\0\1"    -- the Internet class
 
     if byte(qname, 1) == DOT_CHAR then


### PR DESCRIPTION
We need to support an experimental TYPE65535 query, but the current DNS
parser only accepts up to 255. Fix this and add a test to check for the
CCA record (RFC 6844, authored by Comodo) which has type 257.

For other registrations, see
https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
___
While at it, also remove an unnecessary module from .travis.yml.