### PR TITLE
travis-ci: do not build lua-cjson

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,11 @@ env:
 install:
     - sudo cpanm --notest Test::Nginx > build.log 2>&1 || (cat build.log && exit 1)
     - git clone https://github.com/openresty/openresty.git ../openresty
-    - git clone https://github.com/openresty/lua-cjson.git
     - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
     - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
     - git clone https://github.com/openresty/nginx-devel-utils.git
 
 script:
-  - cd lua-cjson && make -j$JOBS && sudo make install && cd ..
   - export PATH=$PWD/work/nginx/sbin:$PWD/nginx-devel-utils:$PATH
   - ngx-build $NGINX_VERSION --with-debug --with-cc-opt="-DDEBUG_MALLOC" --with-ipv6 --add-module=../lua-nginx-module  > build.log 2>&1 || (cat build.log && exit 1)
   - prove -r t


### PR DESCRIPTION
This was removed in the previous release in favor of ljson.