### PR TITLE
bugfix: fix parsing state after SOA record

### DIFF
--- a/lib/resty/dns/resolver.lua
+++ b/lib/resty/dns/resolver.lua
@@ -580,6 +580,8 @@ local function parse_section(answers, section, buf, start_pos, size,
                 p = p + 4
             end
 
+            pos = p
+
         else
             -- for unknown types, just forward the raw value
 

--- a/lib/resty/dns/resolver.lua
+++ b/lib/resty/dns/resolver.lua
@@ -84,7 +84,7 @@ local resolver_errstrs = {
     "refused",          -- 5
 }
 
-local soa_int32_fields = { "serial", "refresh", "retry", "expire", "mininum" }
+local soa_int32_fields = { "serial", "refresh", "retry", "expire", "minimum" }
 
 local mt = { __index = _M }
 

--- a/t/TestDNS.pm
+++ b/t/TestDNS.pm
@@ -9,6 +9,7 @@ use Test::Nginx::Socket::Lua -Base;
 
 use constant {
     TYPE_A => 1,
+    TYPE_SOA => 6,
     TYPE_TXT => 16,
     TYPE_CNAME => 5,
     TYPE_AAAA => 28,
@@ -310,6 +311,16 @@ sub encode_record ($) {
         $rddata //= pack("nnn", $ans->{priority}, $ans->{weight}, $ans->{port}) . encode_name($srv);
         $rdlength //= length $rddata;
         $type //= TYPE_SRV;
+        $class //= CLASS_INTERNET;
+    }
+
+    my $soa = $ans->{soa};
+    if (defined $soa) {
+        my $data = encode_name($soa) . encode_name($ans->{rname});
+        $data .= pack("NNNNN", $ans->{serial}, $ans->{refresh}, $ans->{retry}, $ans->{expire}, $ans->{minimum});
+        $rddata //= $data;
+        $rdlength //= length $rddata;
+        $type //= TYPE_SOA;
         $class //= CLASS_INTERNET;
     }
 

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -574,7 +574,7 @@ a.7.1.4.c.0.0.2.0.0.8.0.8.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.0.1.ip6.arpa
 --- request
 GET /t
 --- response_body_like chop
-^records: \[(?:{"class":1,"expire":\d+,"mininum":\d+,"mname":"ns\d+\.google\.com","name":"google\.com","refresh":\d+,"retry":\d+,"rname":"dns-admin\.google\.com","section":2,"serial":\d+,"ttl":\d+,"type":6},?)+\]$
+^records: \[(?:{"class":1,"expire":\d+,"minimum":\d+,"mname":"ns\d+\.google\.com","name":"google\.com","refresh":\d+,"retry":\d+,"rname":"dns-admin\.google\.com","section":2,"serial":\d+,"ttl":\d+,"type":6},?)+\]$
 --- no_error_log
 [error]
 --- no_check_leak


### PR DESCRIPTION
Correct parsing of Additional Records failed due to a bad parsing state
after processing a SOA record in the Authorative nameservers section.
___
There is no regression test for this "trivial" fix since the only way I know of is to do a query against an authorative DNS server, e.g.:

    dig SOA google.com @ns1.google.com

however, the current tests seems designed such that it can work without relying on an external DNS server (by setting `TEST_NGINX_RESOLVER`). Hope this is OK?

(and yet another option is to do an `ANY` query, e.g. `dig ANY example.com`, but this type has been deprecated...)