### PR TITLE
feat: add no_random option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -78,6 +78,7 @@ server {
                 nameservers = {"8.8.8.8", {"8.8.4.4", 53} },
                 retrans = 5,  -- 5 retransmissions on receive timeout
                 timeout = 2000,  -- 2 sec
+                no_random = true, -- always start with first nameserver
             }
 
             if not r then
@@ -134,6 +135,9 @@ It accepts a `opts` table argument. The following options are supported:
 * `no_recurse`
 
 	a boolean flag controls whether to disable the "recursion desired" (RD) flag in the UDP request. Defaults to `false`.
+* `no_random`
+
+	a boolean flag controls whether to randomly pick the nameserver to query first, if `true` will always start with the first nameserver listed. Defaults to `false`.
 
 [Back to TOC](#table-of-contents)
 

--- a/lib/resty/dns/resolver.lua
+++ b/lib/resty/dns/resolver.lua
@@ -152,7 +152,8 @@ function _M.new(class, opts)
     tcp_sock:settimeout(timeout)
 
     return setmetatable(
-                { cur = rand(1, n), socks = socks,
+                { cur = opts.no_random and 1 or rand(1, n),
+                  socks = socks,
                   tcp_sock = tcp_sock,
                   servers = servers,
                   retrans = opts.retrans or 5,


### PR DESCRIPTION
This allows to honor the `resolv.conf` setting `rotate` (somewhat).

Rotate should round-robin over name-servers for each query to distribute load. Since the library doesn't maintain a global state (and cannot since for each query a new nameserver list is provided). The randomization has the same effect. That was already the default behaviour (and remains), but this option let's the user disable that behaviour now.