### PR TITLE
Added DoH support GET/POST

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -125,7 +125,7 @@ It accepts a `opts` table argument. The following options are supported:
 
 * `nameservers`
 
-	a list of nameservers to be used. Each nameserver entry can be either a single hostname string or a table holding both the hostname string and the port number. The nameserver is picked up by a simple round-robin algorithm for each `query` method call. This option is required.
+	a list of nameservers to be used. Each nameserver entry can be either a single hostname string, DoH url with optional port or a table holding both the hostname string and the port number. The nameserver is picked up by a simple round-robin algorithm for each `query` method call. This option is required.
 * `retrans`
 
 	the total number of times of retransmitting the DNS request when receiving a DNS response times out according to the `timeout` setting. Defaults to `5` times. When trying to retransmit the query, the next nameserver according to the round-robin algorithm will be picked up.
@@ -138,7 +138,10 @@ It accepts a `opts` table argument. The following options are supported:
 * `no_random`
 
 	a boolean flag controls whether to randomly pick the nameserver to query first, if `true` will always start with the first nameserver listed. Defaults to `false`.
+* `doh`
 
+    type of DoH query possible values are `POST`, `GET` or boolean false,  Defaults to nil.
+    
 [Back to TOC](#table-of-contents)
 
 query

--- a/lib/resty/dns/resolver.lua
+++ b/lib/resty/dns/resolver.lua
@@ -874,8 +874,8 @@ function _M.doh_query(self, qname, opts, tries)
             res = ngx.location.capture(servers[idx][1] .. b64.encode_base64url(qname))
         else
             id = _gen_id(self)
-            res = ngx.location.capture(servers[idx][1],
-                    { method = ngx.HTTP_POST, body = _build_request(qname, id, self.no_recurse, opts) })
+            local bdata = table.concat(_build_request(qname, id, self.no_recurse, opts))
+            res = ngx.location.capture(servers[idx][1],{ method = ngx.HTTP_POST, body = bdata })
         end
 
         if res.status == 200 and res.body then


### PR DESCRIPTION
This adds DoH support with POST and GET requests, this requests could be cached.

local r, err = resolver:new{
        nameservers = { "https://cloudflare-dns.com/dns-query" }, 
        retrans = 5,  -- 5 retransmissions on receive timeout
        timeout = 2000,  -- 2 sec
        no_random = true, -- always start with first nameserver,
        doh = 'POST'
    } 