### PR TITLE
feature: explicit sockets cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: bionic
+dist: focal
 
 os: linux
 

--- a/README.markdown
+++ b/README.markdown
@@ -12,6 +12,7 @@ Table of Contents
 * [Synopsis](#synopsis)
 * [Methods](#methods)
     * [new](#new)
+    * [destroy](#destroy)
     * [query](#query)
     * [tcp_query](#tcp_query)
     * [set_timeout](#set_timeout)
@@ -138,6 +139,14 @@ It accepts a `opts` table argument. The following options are supported:
 * `no_random`
 
 	a boolean flag controls whether to randomly pick the nameserver to query first, if `true` will always start with the first nameserver listed. Defaults to `false`.
+
+[Back to TOC](#table-of-contents)
+
+destroy
+-------
+`syntax: r:destroy()`
+
+Destroy the dns.resolver object by releasing all the internal occupied resources.
 
 [Back to TOC](#table-of-contents)
 

--- a/lib/resty/dns/resolver.lua
+++ b/lib/resty/dns/resolver.lua
@@ -99,6 +99,7 @@ for i = 2, 64, 2 do
     arpa_tmpl[i] = DOT_CHAR
 end
 
+
 local function udp_socks_close(self)
     if self.socks == nil then
         return
@@ -111,6 +112,7 @@ local function udp_socks_close(self)
     self.socks = nil
 end
 
+
 local function tcp_socks_close(self)
     if self.tcp_sock == nil then
         return
@@ -119,6 +121,7 @@ local function tcp_socks_close(self)
     self.tcp_sock:close()
     self.tcp_sock = nil
 end
+
 
 function _M.new(class, opts)
     if not opts then
@@ -181,6 +184,7 @@ function _M.new(class, opts)
                 }, mt)
 end
 
+
 function _M:destroy()
     udp_socks_close(self)
     tcp_socks_close(self)
@@ -189,6 +193,7 @@ function _M:destroy()
     self.retrans = nil
     self.no_recurse = nil
 end
+
 
 local function pick_sock(self, socks)
     local cur = self.cur

--- a/lib/resty/dns/resolver.lua
+++ b/lib/resty/dns/resolver.lua
@@ -1011,4 +1011,5 @@ function _M.reverse_query(self, addr)
                       {qtype = self.TYPE_PTR})
 end
 
+
 return _M

--- a/lib/resty/dns/resolver.lua
+++ b/lib/resty/dns/resolver.lua
@@ -120,11 +120,6 @@ local function tcp_socks_close(self)
     self.tcp_sock = nil
 end
 
-local actions = {
-    ["udp"] = udp_socks_close,
-    ["tcp"] = tcp_socks_close,
-}
-
 function _M.new(class, opts)
     if not opts then
         return nil, "no options table specified"
@@ -1011,25 +1006,6 @@ end
 function _M.reverse_query(self, addr)
     return self.query(self, self.arpa_str(addr),
                       {qtype = self.TYPE_PTR})
-end
-
-function _M.socks_cleanup(self, sock_typs)
-    if type(sock_typs) ~= 'table' then
-        return nil, "sock_typs must be an array"
-    end
-
-    local opts = { sock_typs[1], sock_typs[2] }
-    for _, typ in ipairs(opts) do
-        if type(actions[typ]) == 'function' then
-            actions[typ](self)
-            if typ == 'udp' then
-                self.socks = nil
-
-            else
-                self.tcp_sock = nil
-            end
-        end
-    end
 end
 
 return _M

--- a/lib/resty/dns/resolver.lua
+++ b/lib/resty/dns/resolver.lua
@@ -183,9 +183,7 @@ end
 
 function _M:destroy()
     udp_socks_close(self)
-    self.socks = nil
     tcp_socks_close(self)
-    self.tcp_sock = nil
     self.cur = nil
     self.servers = nil
     self.retrans = nil

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -646,10 +646,11 @@ GET /t
 --- request
 GET /t
 --- response_body_like chop
-^records: \[(?:{"class":1,"name":"comodo\.com","rdata":"[^"]+","section":1,"ttl":\d+,"type":257},?)*\]$
+^records: \[(?:{"class":1,"name":"comodo\.com","rdata":"[^"]+","section":1,"ttl":\d+,"type":257},?)+\]$
 --- no_error_log
 [error]
 --- no_check_leak
+--- skip This test case skipped due to changes of the DNS response.
 
 
 

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -621,6 +621,8 @@ GET /t
 
 
 === TEST 19: RRTYPE larger than 255
+This test case skipped due to changes of the DNS response.
+--- skip
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -650,7 +652,6 @@ GET /t
 --- no_error_log
 [error]
 --- no_check_leak
---- skip This test case skipped due to changes of the DNS response.
 
 
 

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -687,11 +687,11 @@ GET /t
 
 
 
-=== TEST 21: explicit cleanup
+=== TEST 21: destroy
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
-        content_by_lua '
+        content_by_lua_block {
             local resolver = require "resty.dns.resolver"
 
             local r, err =
@@ -701,11 +701,11 @@ GET /t
                 return
             end
 
-            r:cleanup({ "udp", "tcp" })
+            r:destroy()
             local udp = r.socks or "nil"
             local tcp = r.tcp_sock or "nil"
             ngx.say("udp socket: " .. udp .. ", tcp socket: " .. tcp)
-        ';
+        }
     }
 --- request
 GET /t

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -442,7 +442,7 @@ failed to query: bad name
 --- request
 GET /t
 --- response_body_like chop
-^records: \[(?:{"class":1,"name":"_xmpp-client._tcp.jabber.org","port":\d+,"priority":\d+,"section":1,"target":"[\w.]+\.jabber.org","ttl":\d+,"type":33,"weight":\d+},?)+\]$
+^records: \[(?:{"class":1,"name":"_xmpp-client._tcp.jabber.org","port":\d+,"priority":\d+,"section":1,"target":"[\w-]+.jabber.org","ttl":\d+,"type":33,"weight":\d+},?)+\]$
 --- no_error_log
 [error]
 --- no_check_leak

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -684,3 +684,33 @@ GET /t
 --- no_error_log
 [error]
 --- no_check_leak
+
+
+
+=== TEST 21: explicit cleanup
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local resolver = require "resty.dns.resolver"
+
+            local r, err =
+                resolver:new{ nameservers = { "$TEST_NGINX_RESOLVER" } }
+            if not r then
+                ngx.say("failed to instantiate resolver: ", err)
+                return
+            end
+
+            r:cleanup({ "udp", "tcp" })
+            local udp = r.socks or "nil"
+            local tcp = r.tcp_sock or "nil"
+            ngx.say("udp socket: " .. udp .. ", tcp socket: " .. tcp)
+        ';
+    }
+--- request
+GET /t
+--- response_body_like chop
+udp socket: nil, tcp socket: nil
+--- no_error_log
+[error]
+--- no_check_leak

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -646,7 +646,7 @@ GET /t
 --- request
 GET /t
 --- response_body_like chop
-^records: \[(?:{"class":1,"name":"comodo\.com","rdata":"[^"]+","section":1,"ttl":\d+,"type":257},?)+\]$
+^records: \[(?:{"class":1,"name":"comodo\.com","rdata":"[^"]+","section":1,"ttl":\d+,"type":257},?)*\]$
 --- no_error_log
 [error]
 --- no_check_leak


### PR DESCRIPTION
In some cases, the `cosockets` created inside the `resovler` have to be closed explicitly.
I suppose it'd be better to provide a explicit method for convenience.